### PR TITLE
Handle expected proxy format.  Handle no checksum

### DIFF
--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -75,7 +75,7 @@ describe 'jenkins::plugin' do
 
     it do
       should contain_archive('myplug.hpi').with(
-        :proxy_server => "proxy.company.com:8080",
+        :proxy_server => "http://proxy.company.com:8080",
       )
     end
   end


### PR DESCRIPTION
Hi.  I ran into a namespace conflict on [puppet/camptocamp]/archive with the official module and tried your fork to resolve the issue.  It worked for me with a couple of minor tweaks, which you may like to add to your fork.

Thanks

Simon